### PR TITLE
Additional Windows fixes

### DIFF
--- a/autoload/filebeagle.vim
+++ b/autoload/filebeagle.vim
@@ -97,7 +97,7 @@ endfunction
 
 function! s:parent_dir(current_dir)
     let l:current_dir = fnamemodify(a:current_dir, ":p")
-    if (has("win16") || has("win32") || has("win64")) && !&shellslash
+    if has("win16") || has("win32") || has("win64")
         let d = join(split(l:current_dir, s:sep_as_pattern)[:-2], s:sep)
         if empty(d)
             let d = a:current_dir

--- a/plugin/filebeagle.vim
+++ b/plugin/filebeagle.vim
@@ -65,7 +65,7 @@ function! s:OpenDirHere(dir)
     if isdirectory(a:dir)
         let l:focal_dir = a:dir
         let l:focal_file = bufnr("%")
-        if has("win32")
+        if (has("win16") || has("win32") || has("win64")) && !&shellslash
             let l:focal_dir = substitute(l:focal_dir, '/', '\\', 'g')
             let l:focal_file = substitute(l:focal_file, '/', '\\', 'g')
         endif


### PR DESCRIPTION
For shellslash (forward-slash-mode on Windows):
1. Re-enable the drive-letter logic in parent_dir (it's still needed).
2. Disable the path-separator replacement in OpenDirHere (it causes
problems).