### PR TITLE
fixes blank directory names when glob returns `//`

### DIFF
--- a/autoload/filebeagle.vim
+++ b/autoload/filebeagle.vim
@@ -161,6 +161,7 @@ function! s:discover_paths(current_dir, glob_pattern, is_include_hidden, is_incl
     call add(dir_paths, s:build_current_parent_dir_entry(a:current_dir))
     for path_entry in paths
         let path_entry = substitute(path_entry, s:sep_as_pattern.'\+', s:sep, 'g')
+        let path_entry = substitute(path_entry, s:sep_as_pattern.'$', '', 'g')
         let full_path = fnamemodify(path_entry, ":p")
         let basename = fnamemodify(path_entry, ":t")
         let dirname = fnamemodify(path_entry, ":h")


### PR DESCRIPTION
I was having trouble with directories with angle brackets in the directory names. Here is a simplified example structure:

```
$ anglebracket-example  tree .
.
├── README.md
├── requirements
│   └── base.txt
└── {{cookiecutter_repo_name}}
    ├── bin
    │   └── run.sh
    ├── manage.py
    └── {{cookiecutter_repo_name}}
        └── app.py

4 directories, 5 files
```

I was then getting the following screens when trying to navigate through this project:

![screen shot 2015-04-13 at 11 11 09](https://cloud.githubusercontent.com/assets/794070/7113685/356aa150-e1ce-11e4-969a-12358a060a5e.png)
![screen shot 2015-04-13 at 11 11 16](https://cloud.githubusercontent.com/assets/794070/7113690/398378ca-e1ce-11e4-862b-e0de70d94feb.png)
![screen shot 2015-04-13 at 11 11 28](https://cloud.githubusercontent.com/assets/794070/7113692/3d152722-e1ce-11e4-9473-6f99a2c2f905.png)

I believe the issue was being caused when substituting out double separators. if the double seperator was at the end of the line (i.e `foo/bar//`) the subsitution was leaving a trailing slash (i.e. `foo/bar/`), which in turn was breaking `fnamemodify(path, ':t')` as the tail was always empty.

this patch just subs out that trailing separator.