### PR TITLE
checks gitignore

### DIFF
--- a/autoload/filebeagle.vim
+++ b/autoload/filebeagle.vim
@@ -152,6 +152,14 @@ function! s:discover_paths(current_dir, glob_pattern, is_include_hidden, is_incl
         let path_str = glob(a:current_dir.s:sep.a:glob_pattern)
     endif
     let paths = split(path_str, '\n')
+    if g:filebeagle_check_gitignore && !a:is_include_ignored && executable('git')
+      let gitignored = systemlist(
+            \ 'cd ' . a:current_dir . '; ' .
+            \ 'git check-ignore ' . a:current_dir . s:sep .  '*')
+      if !v:shell_error
+        call filter(paths, 'index(gitignored, v:val) == -1')
+      endif
+    endif
     call sort(paths)
     let &wildignore = old_wildignore
     let &suffixes = old_suffixes

--- a/doc/filebeagle.txt
+++ b/doc/filebeagle.txt
@@ -307,6 +307,11 @@ g:filebeagle_show_line_relativenumbers~ *g:filebeagle_show_line_relativenumbers*
     invoked). If -1 (default), then no relative number options will be
     explicitly set or unset.
 
+g:filebeagle_check_gitignore~                    *g:filebeagle_check_gitignore*
+    Default: 0
+    If 1, filebeagle will attempt to exclude gitignored files. Requires
+    external git binary on system path.
+
 ===============================================================================
                                                         *filebeagle-autocommands*
 CUSTOM AUTOCOMMANDS~

--- a/plugin/filebeagle.vim
+++ b/plugin/filebeagle.vim
@@ -42,7 +42,7 @@ let g:filebeagle_buffer_background_key_map_prefix = get(g:, 'filebeagle_buffer_b
 let g:filebeagle_buffer_normal_key_maps = get(g:, 'filebeagle_buffer_normal_key_maps', {})
 let g:filebeagle_buffer_visual_key_maps = get(g:, 'filebeagle_buffer_visual_key_maps', {})
 let g:filebeagle_buffer_map_movement_keys = get(g:, 'filebeagle_buffer_map_movement_keys', 1)
-let g:filebeagle_check_gitignore = get(g:, 'filebeagle_check_gitignore', 1)
+let g:filebeagle_check_gitignore = get(g:, 'filebeagle_check_gitignore', 0)
 
 " 1}}}
 

--- a/plugin/filebeagle.vim
+++ b/plugin/filebeagle.vim
@@ -42,6 +42,7 @@ let g:filebeagle_buffer_background_key_map_prefix = get(g:, 'filebeagle_buffer_b
 let g:filebeagle_buffer_normal_key_maps = get(g:, 'filebeagle_buffer_normal_key_maps', {})
 let g:filebeagle_buffer_visual_key_maps = get(g:, 'filebeagle_buffer_visual_key_maps', {})
 let g:filebeagle_buffer_map_movement_keys = get(g:, 'filebeagle_buffer_map_movement_keys', 1)
+let g:filebeagle_check_gitignore = get(g:, 'filebeagle_check_gitignore', 1)
 
 " 1}}}
 


### PR DESCRIPTION
so I'm not sure about this as it adds a bit of external overhead.

This checks the files in the target directory against `git check-ignore` and filters the paths by the results.

I'm going to try it out for a week or so and see if it's noticable.