### PR TITLE
Added ability to re-define default statusline

### DIFF
--- a/autoload/filebeagle.vim
+++ b/autoload/filebeagle.vim
@@ -635,7 +635,7 @@ function! s:NewDirectoryViewer()
     function! directory_viewer.setup_buffer_statusline() dict
         if has("statusline")
             let self.old_statusline=&l:statusline
-            setlocal statusline=%{FileBeagleStatusLineCurrentDirInfo()}%=%{FileBeagleStatusLineFilterAndHiddenInfo()}
+            let &l:statusline = g:filebeagle_statusline
         else
             let self.old_statusline=""
         endif
@@ -1125,11 +1125,29 @@ endfunction
 " ==============================================================================
 
 function! FileBeagleStatusLineCurrentDirInfo()
-    if !exists("b:filebeagle_directory_viewer")
-        return ""
+    return exists("b:filebeagle_directory_viewer") ? b:filebeagle_directory_viewer.focus_dir : ''
+endfunction
+
+function! FileBeagleStatusLineHiddenInfo(...)
+    if !exists('b:filebeagle_directory_viewer')
+        return ''
     endif
-    let l:status_line = ' ' . b:filebeagle_directory_viewer.focus_dir . ' '
-    return l:status_line
+    let l:label_hidden_dotfiles = get(a:000, 0, 'dotfiles')
+    let l:label_hidden_wildignore = get(a:000, 1, 'wildignore')
+    let l:label_separator = get(a:000, 2, ', ')
+    let l:status_line = []
+    if empty(b:filebeagle_directory_viewer.is_include_hidden)
+        call add(l:status_line, l:label_hidden_dotfiles)
+    endif
+    if empty(b:filebeagle_directory_viewer.is_include_ignored) && !empty(&wildignore)
+        call add(l:status_line, l:label_hidden_wildignore)
+    endif
+    return join(l:status_line, l:label_separator)
+endfunction
+
+function! FileBeagleStatusLineFilterInfo()
+    return exists("b:filebeagle_directory_viewer") && b:filebeagle_directory_viewer.is_filtered && !empty(b:filebeagle_directory_viewer.filter_exp)
+                \ ? b:filebeagle_directory_viewer.filter_exp : ''
 endfunction
 
 function! FileBeagleStatusLineFilterAndHiddenInfo()
@@ -1137,12 +1155,11 @@ function! FileBeagleStatusLineFilterAndHiddenInfo()
         return ""
     endif
     let l:status_line = ""
-    if b:filebeagle_directory_viewer.is_include_hidden || b:filebeagle_directory_viewer.is_include_ignored
-    else
+    if !empty(FileBeagleStatusLineHiddenInfo())
         let l:status_line .= "[+HIDE]"
     endif
-    if b:filebeagle_directory_viewer.is_filtered && !empty(b:filebeagle_directory_viewer.filter_exp)
-        let l:status_line .= "[+FILTER:".b:filebeagle_directory_viewer.filter_exp . "]"
+    if !empty(FileBeagleStatusLineFilterInfo())
+        let l:status_line .= "[+FILTER:" . FileBeagleStatusLineFilterInfo() . "]"
     endif
     return l:status_line
 endfunction

--- a/doc/filebeagle.txt
+++ b/doc/filebeagle.txt
@@ -313,6 +313,12 @@ g:filebeagle_check_gitignore~                    *g:filebeagle_check_gitignore*
     If 1, filebeagle will attempt to exclude gitignored files. Requires
     external git binary on system path.
 
+g:filebeagle_statusline~                              *g:filebeagle_statusline*
+    Default: %( %{FileBeagleStatusLineCurrentDirInfo()} %)%=%( 
+    %{FileBeagleStatusLineFilterAndHiddenInfo()} %)
+    Defines a statusbar used by filebeagle. See |statusline| for more 
+    information.
+
 ===============================================================================
                                                         *filebeagle-autocommands*
 CUSTOM AUTOCOMMANDS~
@@ -340,6 +346,5 @@ FileBeagleReadPost      After creation, full setup (options, key mappings,
                         commands, etc.) of the FileBeagle buffer, and
                         after the directory information has been read,
                         parsed, and rendered.
-
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/filebeagle.vim
+++ b/plugin/filebeagle.vim
@@ -43,6 +43,7 @@ let g:filebeagle_buffer_normal_key_maps = get(g:, 'filebeagle_buffer_normal_key_
 let g:filebeagle_buffer_visual_key_maps = get(g:, 'filebeagle_buffer_visual_key_maps', {})
 let g:filebeagle_buffer_map_movement_keys = get(g:, 'filebeagle_buffer_map_movement_keys', 1)
 let g:filebeagle_check_gitignore = get(g:, 'filebeagle_check_gitignore', 0)
+let g:filebeagle_statusline = get(g:, 'filebeagle_statusline', '%( %{FileBeagleStatusLineCurrentDirInfo()} %)%=%( %{FileBeagleStatusLineFilterAndHiddenInfo()} %)')
 
 " 1}}}
 


### PR DESCRIPTION
- Added `g:filebeagle_statusline` which allows users to define a custom
statusline.

- Added `FileBeagleStatusLineFilterInfo()` autoloaded function used to
display only the current filter in the statusline.

- Added `FileBeagleStatusLineHiddenInfo()` autoloaded function used to
display verbose information about files currently hidden from view.