### PR TITLE
Remove CWD from path when opening files

### DIFF
--- a/autoload/filebeagle.vim
+++ b/autoload/filebeagle.vim
@@ -898,7 +898,7 @@ function! s:NewDirectoryViewer()
         endif
         let l:opened_basenames = []
         for l:entry in a:selected_entries
-            let l:path_to_open = fnameescape(l:entry.full_path)
+            let l:path_to_open = fnameescape(fnamemodify(l:entry.full_path, ":."))
             try
                 execute l:split_cmd . " " . l:path_to_open
             catch /E37:/


### PR DESCRIPTION
I like "%" to be the path relative to the current working directory. At the moment it's always the absolute path.