### PR TITLE
add option to show/hide parent

### DIFF
--- a/autoload/filebeagle.vim
+++ b/autoload/filebeagle.vim
@@ -171,7 +171,9 @@ function! s:discover_paths(current_dir, glob_pattern, is_include_hidden, is_incl
     let dir_paths = []
     let file_paths = []
     " call add(dir_paths, s:GetCurrentDirEntry(l:current_dir))
-    call add(dir_paths, s:build_current_parent_dir_entry(l:current_dir))
+    if g:filebeagle_show_parent 
+      call add(dir_paths, s:build_current_parent_dir_entry(l:current_dir))
+    endif
     for path_entry in paths
         let path_entry = substitute(path_entry, s:sep_as_pattern.'\+', s:sep, 'g')
         let path_entry = substitute(path_entry, s:sep_as_pattern.'$', '', 'g')

--- a/doc/filebeagle.txt
+++ b/doc/filebeagle.txt
@@ -294,6 +294,10 @@ g:filebeagle_show_hidden~                            *g:filebeagle_show_hidden*
     Show hidden and (wild-)ignored files by default (can be toggled when
     viewing a directory using 'gh').
 
+g:filebeagle_show_parent                            *g:filebeagle_show_parent*
+    Default: 1
+    If specified as 1, show entry to navigate to parent directory (../).
+
 g:filebeagle_show_line_numbers~                *g:filebeagle_show_line_numbers*
     Default: -1
     If 0, then line numbers (see |nu|) will be suppressed in the directory

--- a/plugin/filebeagle.vim
+++ b/plugin/filebeagle.vim
@@ -35,6 +35,7 @@ set cpo&vim
 let g:filebeagle_hijack_netrw = get(g:, 'filebeagle_hijack_netrw', 1)
 let g:filebeagle_suppress_keymaps = get(g:, 'filebeagle_suppress_keymaps', 0)
 let g:filebeagle_show_hidden = get(g:, 'filebeagle_show_hidden', 0)
+let g:filebeagle_show_parent = get(g:, 'filebeagle_show_parent', 1)
 let g:filebeagle_show_line_numbers = get(g:, 'filebeagle_show_line_numbers', -1)
 let g:filebeagle_show_line_relativenumbers = get(g:, 'filebeagle_show_line_relativenumbers', -1)
 let g:filebeagle_buffer_legacy_key_maps = get(g:, 'filebeagle_buffer_legacy_key_maps', 0)


### PR DESCRIPTION
First off, just wanted to say thanks for filebeagle! I really like the simplicity.


Use case: I often find myself traversing directory structures that have only a single directory in them. So, it would be nice to be able to just quickly dive through them.

Given that "go up a directory" is already bound to `-` by default, I also don't really need the `../` entry at all.

This PR adds an option to disable showing that. It defaults to being on so that behavior doesn't change until you explicitly set the option.